### PR TITLE
update_turbolinks

### DIFF
--- a/app/assets/stylesheets/modules/_mypage-top.scss
+++ b/app/assets/stylesheets/modules/_mypage-top.scss
@@ -221,7 +221,6 @@ body {
             line-height: 30px;
             text-align: center;
             margin: auto;
-            width: 100px;
             height: 30px;
           }
           &_box {

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -92,7 +92,7 @@
         - if @item.seller_id == current_user.id
           .item__affix
             .item__affix__edit
-              = link_to '商品の編集', edit_item_path(@item)
+              = link_to '商品の編集', edit_item_path(@item), data: {"turbolinks" => false}
             .item__affix__delete
 
               = link_to '商品の削除', item_path(@item),method: :delete


### PR DESCRIPTION

#What
  マイページのView崩れの修正
  商品編集画面のカテゴリー機能の修正

#Why
  本番環境でニックネームの表示部分が、文字数オーバーで崩れていたから
  商品編集画面にて、turbolinksによりリロードをしないとカテゴリーが選択できなかったから